### PR TITLE
Add proprietary ids

### DIFF
--- a/bin/onix3_to_onix3.rb
+++ b/bin/onix3_to_onix3.rb
@@ -31,7 +31,15 @@ builder = Nokogiri::XML::Builder.new(:encoding => "UTF-8") do |xml|
         xml.ProductIDType("03")
         xml.IDValue(product.ean)
       }
-
+      product.proprietary_ids.each do |id|
+        xml.ProductIdentifier {
+          xml.ProductIDType("01")
+          if id.name
+            xml.IDTypeName(id.name)
+          end
+          xml.IDValue(id.value)
+        }
+      end
       xml.DescriptiveDetail {
         if product.bundle?
           xml.ProductComposition("10")

--- a/lib/onix/descriptive_detail.rb
+++ b/lib/onix/descriptive_detail.rb
@@ -111,6 +111,7 @@ module ONIX
     attr_accessor :part_of
 
     include EanMethods
+    include ProprietaryIdMethods
 
     def initialize
       @identifiers = []

--- a/lib/onix/identifier.rb
+++ b/lib/onix/identifier.rb
@@ -73,17 +73,6 @@ module ONIX
 
   module ProprietaryIdMethods
     def proprietary_ids
-      [].tap do |prop_ids|
-        proprietary_ids_identifiers.each do |identifier|
-          prop_ids << {
-            :value => identifier.value,
-            :name => identifier.name,
-          }
-        end
-      end
-    end
-    # private
-    def proprietary_ids_identifiers
       @identifiers.select{|id| id.type.human=="Proprietary"}
     end
   end

--- a/lib/onix/identifier.rb
+++ b/lib/onix/identifier.rb
@@ -64,4 +64,21 @@ module ONIX
       @identifiers.select{|id| id.type.human=="Gln"}.first
     end
   end
+
+  module ProprietaryIdMethods
+    def proprietary_ids
+      [].tap do |prop_ids|
+        proprietary_ids_identifiers.each do |identifier|
+          prop_ids << {
+            :value => identifier.value,
+            :name => nil, #todo
+          }
+        end
+      end
+    end
+    # private
+    def proprietary_ids_identifiers
+      @identifiers.select{|id| id.type.human=="Proprietary"}
+    end
+  end
 end

--- a/lib/onix/identifier.rb
+++ b/lib/onix/identifier.rb
@@ -4,6 +4,8 @@ module ONIX
     attr_accessor :type
     # IDValue string value
     attr_accessor :value
+    # IDTypeName string value
+    attr_accessor :name
 
     # create Identifier array from Nokogiri:XML::Node
     def self.parse_identifiers(node,prefix_tag)
@@ -16,7 +18,11 @@ module ONIX
     end
 
     def self.parse_identifier(node,prefix_tag)
-      Identifier.from_hash({:type=>ONIX.const_get("#{prefix_tag}IDType").from_code(node.at_xpath("./#{prefix_tag}IDType").text), :value=>node.at_xpath("./IDValue").text})
+      identifier = Identifier.from_hash({:type => ONIX.const_get("#{prefix_tag}IDType").from_code(node.at_xpath("./#{prefix_tag}IDType").text), :value => node.at_xpath("./IDValue").text})
+      if node.at_xpath("./IDTypeName")
+        identifier.name = node.at_xpath("./IDTypeName").text
+      end
+      identifier
     end
 
     def uniq_id
@@ -71,7 +77,7 @@ module ONIX
         proprietary_ids_identifiers.each do |identifier|
           prop_ids << {
             :value => identifier.value,
-            :name => nil, #todo
+            :name => identifier.name,
           }
         end
       end

--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -38,6 +38,7 @@ module ONIX
 
 
     include EanMethods
+    include ProprietaryIdMethods
 
     # :category: High level
     # product title string

--- a/test/fixtures/9782752906700.xml
+++ b/test/fixtures/9782752906700.xml
@@ -244,6 +244,7 @@
   <NotificationType>03</NotificationType>
   <ProductIdentifier>
     <ProductIDType>01</ProductIDType>
+    <IDTypeName>SKU</IDTypeName>
     <IDValue>O192530</IDValue>
   </ProductIdentifier>
   <ProductIdentifier>

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -24,6 +24,10 @@ class TestImOnix < Minitest::Test
       assert_equal "immateriel.fr-O192530", @product.record_reference
     end
 
+    should "have proprietary ids" do
+      assert_equal 'O192530', @product.proprietary_ids.first[:value]
+    end
+
     should "have title" do
       assert_equal "Certaines n'avaient jamais vu la mer", @product.title
     end

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -24,8 +24,9 @@ class TestImOnix < Minitest::Test
       assert_equal "immateriel.fr-O192530", @product.record_reference
     end
 
-    should "have proprietary ids" do
+    should "have a named proprietary id" do
       assert_equal 'O192530', @product.proprietary_ids.first[:value]
+      assert_equal 'SKU', @product.proprietary_ids.first[:name]
     end
 
     should "have title" do

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -25,8 +25,8 @@ class TestImOnix < Minitest::Test
     end
 
     should "have a named proprietary id" do
-      assert_equal 'O192530', @product.proprietary_ids.first[:value]
-      assert_equal 'SKU', @product.proprietary_ids.first[:name]
+      assert_equal 'O192530', @product.proprietary_ids.first.value
+      assert_equal 'SKU', @product.proprietary_ids.first.name
     end
 
     should "have title" do


### PR DESCRIPTION
J'ajoute une méthode pour extraire les ID "propriétaires", dont on a besoin pour certains diffuseurs.

J'ai dû ajouter un accesseur pour sortir le `<IDTypeName>` qui, je cite,

> Must be included when, and only when, the code in the `<ProductIDType>` element indicates a proprietary scheme, eg a wholesaler’s own code. Optional and non-repeating.

Je me demande si on ne pourrait pas changer le type de retour : au lieu de retourner un tableau de hash, retourner un tableau d'objets ? Ça me gêne que partout ailleurs on puisse utiliser la syntaxe `truc.bidule`, et que juste ici je doive utiliser `truc[:bidule]`. Je ne sais pas si c'est vraiment gênant ou si c'est juste que j'ai fait trop de JS ces derniers temps.

Ping @edas @oservieres @astranchet 
