### PR TITLE
Dev/extract file format from related products

### DIFF
--- a/lib/onix/related_material.rb
+++ b/lib/onix/related_material.rb
@@ -11,6 +11,7 @@ module ONIX
     attr_accessor :form_details
 
     include EanMethods
+    include ProprietaryIdMethods
 
     def initialize
       @identifiers = []

--- a/lib/onix/related_material.rb
+++ b/lib/onix/related_material.rb
@@ -8,10 +8,13 @@ module ONIX
 
     attr_accessor :form
 
+    attr_accessor :form_details
+
     include EanMethods
 
     def initialize
       @identifiers = []
+      @form_details = []
     end
 
     def parse(n)
@@ -23,8 +26,18 @@ module ONIX
             @code=ProductRelationCode.from_code(t.text)
           when "ProductForm"
             @form=ProductForm.from_code(t.text)
+          when "ProductFormDetail"
+            @form_details << ProductFormDetail.from_code(t.text)
         end
       end
+    end
+
+    def file_format
+      file_formats.first.human if file_formats.first
+    end
+
+    def file_formats
+      @form_details.select{|fd| fd.code =~ /^E1.*/}
     end
   end
 

--- a/test/fixtures/9782752906700.xml
+++ b/test/fixtures/9782752906700.xml
@@ -488,6 +488,10 @@
         <IDValue>9782752906700</IDValue>
       </ProductIdentifier>
       <ProductIdentifier>
+        <ProductIDType>01</ProductIDType>
+        <IDValue>RP64128-print</IDValue>
+      </ProductIdentifier>
+      <ProductIdentifier>
         <ProductIDType>15</ProductIDType>
         <IDValue>9782752906700</IDValue>
       </ProductIdentifier>

--- a/test/fixtures/9782752906700.xml
+++ b/test/fixtures/9782752906700.xml
@@ -473,6 +473,15 @@
   </PublishingDetail>
   <RelatedMaterial>
     <RelatedProduct>
+      <ProductRelationCode>06</ProductRelationCode>
+      <ProductIdentifier>
+        <ProductIDType>03</ProductIDType>
+        <IDValue>9781111111111</IDValue>
+      </ProductIdentifier>
+      <ProductForm>EA</ProductForm>
+      <ProductFormDetail>E107</ProductFormDetail>
+    </RelatedProduct>
+    <RelatedProduct>
       <ProductRelationCode>13</ProductRelationCode>
       <ProductIdentifier>
         <ProductIDType>03</ProductIDType>

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -72,8 +72,10 @@ class TestImOnix < Minitest::Test
       end
     end
 
-    should "have a printed equivalent" do
-      assert_equal "9782752906700", @product.print_product.ean
+    should "have a printed equivalent with a proprietary id" do
+      print = @product.print_product
+      assert_equal "9782752906700", print.ean
+      assert_equal "RP64128-print", print.proprietary_ids.first.value
     end
 
     should "have a PDF equivalent" do

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -72,6 +72,16 @@ class TestImOnix < Minitest::Test
       end
     end
 
+    should "have a printed equivalent" do
+      assert_equal "9782752906700", @product.print_product.ean
+    end
+
+    should "have a PDF equivalent" do
+      pdf = @product.related_material.alternative_format_products.first
+      assert_equal "9781111111111", pdf.ean
+      assert_equal "Pdf", pdf.file_format
+    end
+
     should "not provide info about fixed layout or not" do
       assert_equal nil, @product.reflowable?
     end
@@ -109,8 +119,9 @@ class TestImOnix < Minitest::Test
     end
 
     should "be a part of its main product" do
-      assert_equal "9782752908643", @product.part_of_product.ean
-      assert_equal "O192530", @product.part_of_product.proprietary_ids.first.value
+      parent = @product.part_of_product
+      assert_equal "9782752908643", parent.ean
+      assert_equal "O192530", parent.proprietary_ids.first.value
     end
   end
 

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -29,6 +29,10 @@ class TestImOnix < Minitest::Test
       assert_equal nil, @message.sender.gln
     end
 
+    should "have an EAN13" do
+      assert_equal "9782752908643", @product.ean
+    end
+
     should "have a named proprietary id" do
       assert_equal 'O192530', @product.proprietary_ids.first.value
       assert_equal 'SKU', @product.proprietary_ids.first.name
@@ -102,6 +106,11 @@ class TestImOnix < Minitest::Test
 
     should "have epub file format" do
       assert_equal "Epub", @product.file_format
+    end
+
+    should "be a part of its main product" do
+      assert_equal "9782752908643", @product.part_of_product.ean
+      assert_equal "O192530", @product.part_of_product.proprietary_ids.first.value
     end
   end
 


### PR DESCRIPTION
J'ajoute des fonctionnalités intéressantes autour des produits "related" (produit "père" ou formats alternatifs) : 
- accesseur facile sur les identifiants "propriétaires" de ces produits,
- accès aux formats de ces produits.
