### PR TITLE
Mod: prefer testing on human value instead of onix code

### DIFF
--- a/lib/onix/descriptive_detail.rb
+++ b/lib/onix/descriptive_detail.rb
@@ -386,7 +386,7 @@ module ONIX
     end
 
     def streaming?
-      @form.code=="EC"
+      @form.human=="DigitalOnline"
     end
 
     def bundle?


### PR DESCRIPTION
Nouvelle PR en réponse au commentaire suivant 

> Thanks ! As a general note, the main idea behind this gem is to hide ONIX's codelist nonsense for better readability (especally for high-level methods). So @form.human=="DigitalOnline" should be preferred to @form.code=="EC", fd.human=="Reflowable" to fd.code=="E200" and fd.human=="FixedFormat" to fd.code=="E201"
