### PR TITLE
Sales restriction type

### DIFF
--- a/lib/onix/code.rb
+++ b/lib/onix/code.rb
@@ -433,4 +433,11 @@ module ONIX
     end
   end
 
+  class SalesRestrictionType < CodeFromYaml
+    private
+    def self.code_ident
+      71
+    end
+  end
+
 end

--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -415,6 +415,12 @@ module ONIX
       end
     end
 
+    def sales_restriction
+      if @publishing_detail
+        @publishing_detail.sales_restriction
+      end
+    end
+
     # :category: High level
     # product countries rights string array
     def countries_rights

--- a/lib/onix/publishing_detail.rb
+++ b/lib/onix/publishing_detail.rb
@@ -29,10 +29,25 @@ module ONIX
     end
   end
 
+  class SalesRestriction < Subset
+    attr_accessor :type
+
+    def parse(n)
+      n.children.each do |t|
+        case t.name
+          when "SalesRestrictionType"
+            @type = SalesRestrictionType.from_code(t.text)
+        end
+      end
+    end
+
+  end
+
   class PublishingDetail < Subset
     attr_accessor :status, :publishers, :imprints,
                   :sales_rights,
-                  :publishing_dates
+                  :publishing_dates,
+                  :sales_restriction
 
     def initialize
       @sales_rights=[]
@@ -72,6 +87,10 @@ module ONIX
       end
     end
 
+    def sales_restriction
+      @sales_restriction
+    end
+
     def parse(n)
       n.children.each do |t|
         case t.name
@@ -81,6 +100,8 @@ module ONIX
             @sales_rights << SalesRights.from_xml(t)
           when "PublishingDate"
             @publishing_dates << PublishingDate.from_xml(t)
+          when "SalesRestriction"
+            @sales_restriction = SalesRestriction.from_xml(t)
         end
       end
 

--- a/test/fixtures/9782752906700.xml
+++ b/test/fixtures/9782752906700.xml
@@ -77,6 +77,11 @@
       <UnpricedItemType>03</UnpricedItemType>
     </SupplyDetail>
   </ProductSupply>
+  <PublishingDetail>
+    <SalesRestriction>
+      <SalesRestrictionType>09</SalesRestrictionType>
+    </SalesRestriction>
+  </PublishingDetail>
 </Product>
 <!-- Certaines n'avaient jamais vu la mer (110336) multi-format : Epub - Watermark (3019002489901) -->
 <Product>

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -334,4 +334,17 @@ class TestImOnix < Minitest::Test
       assert @product.streaming?
     end
   end
+
+  context 'sales restriction of "Certaines n’avaient jamais vu la mer"' do
+    setup do
+      @message = ONIX::ONIXMessage.new
+      @message.parse("test/fixtures/9782752906700.xml")
+      @product=@message.products.first
+    end
+
+    should "be 09" do
+      assert_equal "09", @product.sales_restriction.type.code
+    end
+  end
+
 end


### PR DESCRIPTION
Extract `SalesRestriction > SalesRestrictionType` from ONIX files.

See [codelist71](http://www.editeur.org/files/ONIX%20for%20books%20-%20code%20lists/ONIX_BookProduct_Codelists_Issue_29.html#codelist71) for the list of possible values.

Ping @oservieres @tut-tuuut 
