### PR TITLE
Return the supplier in the supply details

### DIFF
--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -445,6 +445,7 @@ module ONIX
     #     :including_tax=>bool,
     #     :currency=>string,
     #     :territory=>string,
+    #     :suppliers=>[Supplier,...],
     #     :prices=>[{:amount=>int,
     #                :from_date=>date,
     #                :until_date=>date,
@@ -458,6 +459,7 @@ module ONIX
           ps.supply_details.each do |sd|
             sd.prices.each do |p|
               supply={}
+              supply[:suppliers]=sd.suppliers
               supply[:available]=sd.available?
               supply[:availability_date]=sd.availability_date
 
@@ -567,6 +569,7 @@ module ONIX
                      :territory=>supply.map{|fs| fs.map{|s| s[:territory]}}.flatten.uniq,
                      :available=>fsupply[:available],
                      :availability_date=>fsupply[:availability_date],
+                     :suppliers=>fsupply[:suppliers],
                      :prices=>supply.first.map{|s|
 
                        s[:amount]=s[:price]

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -92,6 +92,10 @@ class TestImOnix < Minitest::Test
       assert_equal "Julie Otsuka", @product.contributors.first.name
     end
 
+    should "have supplier named" do
+      assert_equal "immatériel·fr", @product.supplies_for_country("FR","EUR").first[:suppliers].first.name
+    end
+
     should "be available in France" do
       assert_equal true, @product.supplies_for_country("FR","EUR").first[:available]
     end


### PR DESCRIPTION
J'ai besoin de connaitre le(s) supplier(s) pour chaque _supply detail_. La gem ne l'indiquait pas. Mais ça, c'était avant.

poke @johanpoirier @cGuille 
