### PR TITLE
Complete contributors informations

### DIFF
--- a/lib/onix/code.rb
+++ b/lib/onix/code.rb
@@ -181,6 +181,13 @@ module ONIX
     end
   end
 
+  class ContributorPlaceRelator < CodeFromYaml
+    private
+    def self.code_ident
+      151
+    end
+  end
+
   class ContentAudience < CodeFromYaml
     private
     def self.code_ident

--- a/lib/onix/contributor.rb
+++ b/lib/onix/contributor.rb
@@ -2,7 +2,7 @@ require 'onix/subset'
 
 module ONIX
   class Contributor < Subset
-    attr_accessor :name_before_key, :key_names, :person_name, :inverted_name, :role, :biography_note, :sequence_number
+    attr_accessor :name_before_key, :key_names, :person_name, :inverted_name, :role, :biography_note, :place, :sequence_number
 
     # :category: High level
     # flatten person name (firstname lastname)
@@ -69,6 +69,23 @@ module ONIX
             @biography_note=t.text.strip
           when "ContributorRole"
             @role=ContributorRole.from_code(t.text)
+          when "ContributorPlace"
+            @place=ContributorPlace.from_xml(t)
+        end
+      end
+    end
+
+    class ContributorPlace < Subset
+      attr_accessor :relator, :country_code
+
+      def parse(p)
+        p.children.each do |t|
+          case t.name
+            when "ContributorPlaceRelator"
+              @relator=ContributorPlaceRelator.from_code(t.text)
+            when "CountryCode"
+              @country_code=t.text
+          end
         end
       end
     end

--- a/lib/onix/contributor.rb
+++ b/lib/onix/contributor.rb
@@ -2,7 +2,7 @@ require 'onix/subset'
 
 module ONIX
   class Contributor < Subset
-    attr_accessor :name_before_key, :key_names, :person_name, :role, :biography_note, :sequence_number
+    attr_accessor :name_before_key, :key_names, :person_name, :inverted_name, :role, :biography_note, :sequence_number
 
     # :category: High level
     # flatten person name (firstname lastname)
@@ -13,6 +13,22 @@ module ONIX
         if @key_names
           if @name_before_key
             "#{@name_before_key} #{@key_names}"
+          else
+            @key_names
+          end
+        end
+      end
+    end
+
+    # :category: High level
+    # inverted flatten person name (lastname firstname)
+    def inverted_name
+      if @inverted_name
+        @inverted_name
+      else
+        if @key_names
+          if @name_before_key
+            "#{@key_names}, #{@name_before_key}"
           else
             @key_names
           end
@@ -47,14 +63,15 @@ module ONIX
             @key_names=t.text
           when "PersonName"
             @person_name=t.text
+          when "PersonNameInverted"
+            @inverted_name=t.text
           when "BiographicalNote"
             @biography_note=t.text.strip
           when "ContributorRole"
             @role=ContributorRole.from_code(t.text)
-
         end
       end
-
     end
+
   end
 end

--- a/lib/onix/contributor.rb
+++ b/lib/onix/contributor.rb
@@ -21,19 +21,9 @@ module ONIX
     end
 
     # :category: High level
-    # inverted flatten person name (lastname firstname)
+    # inverted flatten person name
     def inverted_name
-      if @inverted_name
-        @inverted_name
-      else
-        if @key_names
-          if @name_before_key
-            "#{@key_names}, #{@name_before_key}"
-          else
-            @key_names
-          end
-        end
-      end
+      @inverted_name
     end
 
     # :category: High level

--- a/test/fixtures/illustrations.xml
+++ b/test/fixtures/illustrations.xml
@@ -338,6 +338,10 @@
       <NamesBeforeKey>Julie</NamesBeforeKey>
       <KeyNames>Otsuka</KeyNames>
       <BiographicalNote>&lt;p&gt;Julie Otsuka est n&amp;eacute;e en 1962 en Californie. Dipl&amp;ocirc;m&amp;eacute;e en art, elle abandonne une carri&amp;egrave;re de peintre (elle a &amp;eacute;tudi&amp;eacute; cette discipline &amp;agrave; l'universit&amp;eacute; de Yale) pour l'&amp;eacute;criture. Elle publie son premier roman en 2002, &lt;em&gt;Quand l'empereur &amp;eacute;tait un dieu &lt;/em&gt;(Ph&amp;eacute;bus, 2004 ; 10/18, 2008) largement inspir&amp;eacute; de la vie de ses grands-parents. Son deuxi&amp;egrave;me roman, &lt;em&gt;Certaines n'avaient jamais vu la mer &lt;/em&gt;(Ph&amp;eacute;bus, 2012) a &amp;eacute;t&amp;eacute; consid&amp;eacute;r&amp;eacute; aux &amp;Eacute;tats-Unis, d&amp;egrave;s sa sortie, comme un chef-d'oeuvre. Julie Otsuka vit &amp;agrave; New York.&lt;/p&gt;</BiographicalNote>
+      <ContributorPlace>
+        <ContributorPlaceRelator>01</ContributorPlaceRelator>
+        <CountryCode>US</CountryCode>
+      </ContributorPlace>
       <Website>
         <WebsiteLink>http://www.julieotsuka.com/</WebsiteLink>
       </Website>

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -104,6 +104,10 @@ class TestImOnix < Minitest::Test
       assert_equal "Otsuka, Julie", @product.contributors.first.inverted_name
     end
 
+    should "not have author place" do
+      assert_nil @product.contributors.first.place
+    end
+
     should "have supplier named" do
       assert_equal "immatériel·fr", @product.supplies_for_country("FR","EUR").first[:suppliers].first.name
     end
@@ -184,6 +188,19 @@ class TestImOnix < Minitest::Test
 
     should "have format details" do
       assert_equal 1, @product.form_details.length
+    end
+  end
+
+  context "author with place informations" do
+    setup do
+      @message = ONIX::ONIXMessage.new
+      @message.parse("test/fixtures/illustrations.xml")
+      @product=@message.products.last
+    end
+
+    should "have author place" do
+      assert_equal "US", @product.contributors.first.place.country_code
+      assert_equal "BornIn", @product.contributors.first.place.relator.human
     end
   end
 

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -100,6 +100,10 @@ class TestImOnix < Minitest::Test
       assert_equal "Julie Otsuka", @product.contributors.first.name
     end
 
+    should "have author inverted named" do
+      assert_equal "Otsuka, Julie", @product.contributors.first.inverted_name
+    end
+
     should "have supplier named" do
       assert_equal "immatériel·fr", @product.supplies_for_country("FR","EUR").first[:suppliers].first.name
     end


### PR DESCRIPTION
Ajout des infos suivantes concernant les contributors :
- inverted name (tel quel si il est fourni par Onix, ou bien construit sinon à partir du nom et prénom)
- place (code pays et lien avec le pays)

ping @cGuille et @pmartin 
