### PR TITLE
Free of charge territories

### DIFF
--- a/test/fixtures/test_prices6.xml
+++ b/test/fixtures/test_prices6.xml
@@ -74,7 +74,7 @@
     <SupplyDetail>
       <Supplier>
         <SupplierRole>01</SupplierRole>
-        <SupplierName>Hachette Livre</SupplierName>
+        <SupplierName>Vendu Livre</SupplierName>
       </Supplier>
       <ProductAvailability>20</ProductAvailability>
       <SupplyDate>
@@ -86,7 +86,7 @@
     <SupplyDetail>
       <Supplier>
         <SupplierRole>01</SupplierRole>
-        <SupplierName>Hachette Livre</SupplierName>
+        <SupplierName>Vendu Livre</SupplierName>
       </Supplier>
       <ProductAvailability>20</ProductAvailability>
       <SupplyDate>
@@ -98,7 +98,7 @@
     <SupplyDetail>
       <Supplier>
         <SupplierRole>01</SupplierRole>
-        <SupplierName>Hachette Livre</SupplierName>
+        <SupplierName>Vendu Livre</SupplierName>
       </Supplier>
       <ProductAvailability>20</ProductAvailability>
       <SupplyDate>
@@ -110,7 +110,7 @@
     <SupplyDetail>
       <Supplier>
         <SupplierRole>01</SupplierRole>
-        <SupplierName>Hachette Livre</SupplierName>
+        <SupplierName>Vendu Livre</SupplierName>
       </Supplier>
       <ProductAvailability>20</ProductAvailability>
       <SupplyDate>
@@ -122,7 +122,7 @@
     <SupplyDetail>
       <Supplier>
         <SupplierRole>01</SupplierRole>
-        <SupplierName>Hachette Livre</SupplierName>
+        <SupplierName>Vendu Livre</SupplierName>
       </Supplier>
       <ProductAvailability>20</ProductAvailability>
       <SupplyDate>
@@ -134,7 +134,7 @@
     <SupplyDetail>
       <Supplier>
         <SupplierRole>01</SupplierRole>
-        <SupplierName>Hachette Livre</SupplierName>
+        <SupplierName>Vendu Livre</SupplierName>
       </Supplier>
       <ProductAvailability>20</ProductAvailability>
       <SupplyDate>
@@ -146,7 +146,7 @@
     <SupplyDetail>
       <Supplier>
         <SupplierRole>01</SupplierRole>
-        <SupplierName>Hachette Livre</SupplierName>
+        <SupplierName>Vendu Livre</SupplierName>
       </Supplier>
       <ProductAvailability>20</ProductAvailability>
       <SupplyDate>
@@ -158,7 +158,7 @@
     <SupplyDetail>
       <Supplier>
         <SupplierRole>01</SupplierRole>
-        <SupplierName>Hachette Livre</SupplierName>
+        <SupplierName>Vendu Livre</SupplierName>
       </Supplier>
       <ProductAvailability>20</ProductAvailability>
       <SupplyDate>
@@ -184,7 +184,7 @@
     <SupplyDetail>
       <Supplier>
         <SupplierRole>01</SupplierRole>
-        <SupplierName>Hachette Livre</SupplierName>
+        <SupplierName>Vendu Livre</SupplierName>
       </Supplier>
       <ProductAvailability>20</ProductAvailability>
       <Price>

--- a/test/fixtures/test_prices6.xml
+++ b/test/fixtures/test_prices6.xml
@@ -54,14 +54,14 @@
     <SalesRights>
       <SalesRightsType>01</SalesRightsType>
       <Territory>
-        <CountriesIncluded>AT BE BG CY CZ DE ES EE FI FR GR HU IE IT LT LU LV MT NL PL PT RO SK SI</CountriesIncluded>
+        <CountriesIncluded>FR GF GP MC MQ NC PF PM ES IT PT</CountriesIncluded>
       </Territory>
     </SalesRights>
   </PublishingDetail>
   <ProductSupply>
     <Market>
       <Territory>
-        <CountriesIncluded>AT BE CY DE EE ES FI FR GR IE IT LU MT NL PT SI SK SE DK BG CZ HU LT LV PL RO</CountriesIncluded>
+        <CountriesIncluded>FR GF GP MC MQ NC PF PM</CountriesIncluded>
       </Territory>
     </Market>
     <MarketPublishingDetail>
@@ -82,6 +82,126 @@
         <Date>20150401</Date>
       </SupplyDate>
       <UnpricedItemType>01</UnpricedItemType>
+    </SupplyDetail>
+    <SupplyDetail>
+      <Supplier>
+        <SupplierRole>01</SupplierRole>
+        <SupplierName>Hachette Livre</SupplierName>
+      </Supplier>
+      <ProductAvailability>20</ProductAvailability>
+      <SupplyDate>
+        <SupplyDateRole>08</SupplyDateRole>
+        <Date>20150401</Date>
+      </SupplyDate>
+      <UnpricedItemType>01</UnpricedItemType>
+    </SupplyDetail>
+    <SupplyDetail>
+      <Supplier>
+        <SupplierRole>01</SupplierRole>
+        <SupplierName>Hachette Livre</SupplierName>
+      </Supplier>
+      <ProductAvailability>20</ProductAvailability>
+      <SupplyDate>
+        <SupplyDateRole>08</SupplyDateRole>
+        <Date>20150401</Date>
+      </SupplyDate>
+      <UnpricedItemType>01</UnpricedItemType>
+    </SupplyDetail>
+    <SupplyDetail>
+      <Supplier>
+        <SupplierRole>01</SupplierRole>
+        <SupplierName>Hachette Livre</SupplierName>
+      </Supplier>
+      <ProductAvailability>20</ProductAvailability>
+      <SupplyDate>
+        <SupplyDateRole>08</SupplyDateRole>
+        <Date>20150401</Date>
+      </SupplyDate>
+      <UnpricedItemType>01</UnpricedItemType>
+    </SupplyDetail>
+    <SupplyDetail>
+      <Supplier>
+        <SupplierRole>01</SupplierRole>
+        <SupplierName>Hachette Livre</SupplierName>
+      </Supplier>
+      <ProductAvailability>20</ProductAvailability>
+      <SupplyDate>
+        <SupplyDateRole>08</SupplyDateRole>
+        <Date>20150401</Date>
+      </SupplyDate>
+      <UnpricedItemType>01</UnpricedItemType>
+    </SupplyDetail>
+    <SupplyDetail>
+      <Supplier>
+        <SupplierRole>01</SupplierRole>
+        <SupplierName>Hachette Livre</SupplierName>
+      </Supplier>
+      <ProductAvailability>20</ProductAvailability>
+      <SupplyDate>
+        <SupplyDateRole>08</SupplyDateRole>
+        <Date>20150401</Date>
+      </SupplyDate>
+      <UnpricedItemType>01</UnpricedItemType>
+    </SupplyDetail>
+    <SupplyDetail>
+      <Supplier>
+        <SupplierRole>01</SupplierRole>
+        <SupplierName>Hachette Livre</SupplierName>
+      </Supplier>
+      <ProductAvailability>20</ProductAvailability>
+      <SupplyDate>
+        <SupplyDateRole>08</SupplyDateRole>
+        <Date>20150401</Date>
+      </SupplyDate>
+      <UnpricedItemType>01</UnpricedItemType>
+    </SupplyDetail>
+    <SupplyDetail>
+      <Supplier>
+        <SupplierRole>01</SupplierRole>
+        <SupplierName>Hachette Livre</SupplierName>
+      </Supplier>
+      <ProductAvailability>20</ProductAvailability>
+      <SupplyDate>
+        <SupplyDateRole>08</SupplyDateRole>
+        <Date>20150401</Date>
+      </SupplyDate>
+      <UnpricedItemType>01</UnpricedItemType>
+    </SupplyDetail>
+  </ProductSupply>
+  <ProductSupply>
+    <Market>
+      <Territory>
+        <CountriesIncluded>ES IT PT</CountriesIncluded>
+      </Territory>
+    </Market>
+    <MarketPublishingDetail>
+      <MarketPublishingStatus>04</MarketPublishingStatus>
+      <MarketDate>
+        <MarketDateRole>11</MarketDateRole>
+        <Date>20150401</Date>
+      </MarketDate>
+    </MarketPublishingDetail>
+    <SupplyDetail>
+      <Supplier>
+        <SupplierRole>01</SupplierRole>
+        <SupplierName>Hachette Livre</SupplierName>
+      </Supplier>
+      <ProductAvailability>20</ProductAvailability>
+      <Price>
+        <PriceType>04</PriceType>
+        <PriceAmount>10.99</PriceAmount>
+        <Tax>
+          <TaxType>01</TaxType>
+          <TaxRatePercent>5.5</TaxRatePercent>
+          <TaxAmount>1.09</TaxAmount>
+        </Tax>
+        <CurrencyCode>EUR</CurrencyCode>
+        <PriceDate>
+          <PriceDateRole>14</PriceDateRole>
+          <DateFormat>14</DateFormat>
+          <Date>20131001</Date>
+        </PriceDate>
+      </Price>
     </SupplyDetail>
   </ProductSupply>
 </Product>

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -382,16 +382,24 @@ class TestImOnix < Minitest::Test
     end
   end
 
-  context "product that is unpriced" do
+  context "product that contains a supply free of charge" do
     setup do
       @message = ONIX::ONIXMessage.new
       @message.parse("test/fixtures/test_prices6.xml")
       @product=@message.products.last
     end
 
-    should "have a supply free of charge and no prices" do
-      assert_nil @product.supplies.first[:prices]
-      assert_equal 'FreeOfCharge', @product.supplies.first[:unpriced_item_type]
+    should "have a supply with a price for 3 other countries" do
+      priced_supply = @product.supplies.first
+      assert_equal 1, priced_supply[:prices].size
+      assert_equal 3, priced_supply[:territory].size
+    end
+
+    should "have a supply free of charge for 8 countries" do
+      free_supply = @product.supplies.last
+      assert_nil free_supply[:prices]
+      assert_equal 'FreeOfCharge', free_supply[:unpriced_item_type]
+      assert_equal 8, free_supply[:territory].size
     end
   end
 


### PR DESCRIPTION
Suite de la précédente PR pour l'ajout des infos de type `UnpricedItemType`.
Il nous manquait les pays où s'applique le "non-prix" (à l'instar de ce que l'on fait pour les prix).

J'ai donc construit les `Supply` de type `FreeOfCharge` de la même manière que ceux qui ont des prix. Je leur ajoute la liste des pays contenus dans le `Market` du `ProductSupply`.

ping @K-Phoen et @cGuille  
