### PR TITLE
Store price qualifier info

### DIFF
--- a/data/codelists/codelist-59.yml
+++ b/data/codelists/codelist-59.yml
@@ -8,5 +8,5 @@
   '05': ConsumerPrice
   '06': CorporatePrice
   '07': ReservationOrderPrice
-  08: PromotionalOfferPrice
-  09: LinkedPrice
+  '08': PromotionalOfferPrice
+  '09': LinkedPrice

--- a/lib/onix/code.rb
+++ b/lib/onix/code.rb
@@ -272,6 +272,13 @@ module ONIX
     end
   end
 
+  class PriceQualifier < CodeFromYaml
+    private
+    def self.code_ident
+      59
+    end
+  end
+
   class PriceDateRole < CodeFromYaml
     private
     def self.code_ident

--- a/lib/onix/price.rb
+++ b/lib/onix/price.rb
@@ -33,7 +33,7 @@ module ONIX
   end
 
   class Price < Subset
-    attr_accessor :amount, :type, :currency, :dates, :territory, :discount, :tax
+    attr_accessor :amount, :type, :qualifier, :currency, :dates, :territory, :discount, :tax
 
     def initialize
       @dates=[]
@@ -76,6 +76,8 @@ module ONIX
             @territory=Territory.from_xml(t)
           when tag_match("PriceType")
             @type=PriceType.from_code(t.text)
+          when tag_match("PriceQualifier")
+            @qualifier=PriceQualifier.from_code(t.text)
           when tag_match("PriceAmount")
             @amount=(t.text.to_f * 100).round
           when tag_match("Tax")

--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -534,6 +534,7 @@ module ONIX
               supply[:availability_date]=availability_date
 
               supply[:price]=p.amount
+              supply[:qualifier]=p.qualifier.human if p.qualifier
               supply[:including_tax]=p.including_tax?
               if !p.territory or p.territory.countries.length==0
                 supply[:territory]=market_territories

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -672,16 +672,19 @@ class TestImOnix < Minitest::Test
 
       # the first one: 8.99 € (default price) until 2016-07-07
       assert_equal 899, prices[0][:amount]
+      assert_equal 'UnqualifiedPrice', prices[0][:qualifier]
       assert_equal nil, prices[0][:from_date]
       assert_equal Date.new(2016, 7, 7), prices[0][:until_date]
 
       # the second one: 4.99 € (promotional price) from 2016-07-08 to 2016-07-08 (single day)
       assert_equal 499, prices[1][:amount]
+      assert_equal 'PromotionalOfferPrice', prices[1][:qualifier]
       assert_equal Date.new(2016, 7, 8), prices[1][:from_date]
       assert_equal Date.new(2016, 7, 8), prices[1][:until_date]
 
       # the third one: 8.99 € (default price) from 2016-07-09
       assert_equal 899, prices[2][:amount]
+      assert_equal 'UnqualifiedPrice', prices[2][:qualifier]
       assert_equal Date.new(2016, 7, 9), prices[2][:from_date]
       assert_equal nil, prices[2][:until_date]
     end


### PR DESCRIPTION
On stocke l'info `<PriceQualifier>` (cf [ONIX](https://www.bic-media.com/dmrn/codelists/onix-codelist-59.htm)) dans les prix d'un produit :

```json
{
  "prices": [
    {
      "suppliers": [],
      "qualifier": "UnqualifiedPrice",
      "from_date": null,
      "until_date": "2016-07-07",
      "tax": null,
      "amount": 899
    },
    {
      "suppliers": [],
      "qualifier": "PromotionalOfferPrice",
      "from_date": "2016-07-08",
      "until_date": "2016-07-08",
      "tax": null,
      "amount": 499
    },
    {
      "suppliers": [],
      "qualifier": "UnqualifiedPrice",
      "from_date": "2016-07-09",
      "until_date": null,
      "tax": null,
      "amount": 899
    },
  ]
}
```

Si l'info n'est pas présente dans l'ONIX, il n'y aura pas de champ `qualifier` dans le prix.