### PR TITLE
Récupération des sujets (catégories) propriétaires

### DIFF
--- a/lib/onix/descriptive_detail.rb
+++ b/lib/onix/descriptive_detail.rb
@@ -488,6 +488,10 @@ module ONIX
       @subjects.select{|s| s.scheme_identifier.human=="Clil"}
     end
 
+    def proprietary_categories
+      @subjects.select{|s| s.scheme_identifier.human=="ProprietarySubjectScheme"}
+    end
+
     def keywords
       kws=@subjects.select{|s| s.scheme_identifier.human=="Keywords"}.map{|kw| kw.heading_text}.compact
       kws.map{|kw| kw.split(/;|,|\n/)}.flatten.map{|kw| kw.strip}

--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -170,6 +170,11 @@ module ONIX
       self.clil_categories.map{|c| c.code}.uniq
     end
 
+    # Proprietary categories Subject
+    def proprietary_categories
+      @descriptive_detail.proprietary_categories
+    end
+
     # :category: High level
     # keywords string array
     def keywords

--- a/test/fixtures/9782752906700.xml
+++ b/test/fixtures/9782752906700.xml
@@ -371,6 +371,27 @@
       <SubjectSchemeIdentifier>20</SubjectSchemeIdentifier>
       <SubjectHeadingText>destin de femmes, États-Unis d'Amérique, Asie, Oubli, Amérique du Nord, Guerre, Prix Femina étranger 2012, Exil, Amérique, Japon, mariage forcé</SubjectHeadingText>
     </Subject>
+    <Subject>
+      <SubjectSchemeIdentifier>24</SubjectSchemeIdentifier>
+      <SubjectSchemeName>dummy-subject-scheme</SubjectSchemeName>
+      <SubjectCode>100</SubjectCode>
+      <SubjectHeadingText>Dummy Subject</SubjectHeadingText>
+    </Subject>
+    <Subject>
+      <SubjectSchemeIdentifier>24</SubjectSchemeIdentifier>
+      <SubjectSchemeName>dctr:cdfam</SubjectSchemeName>
+      <SubjectCode>200</SubjectCode>
+    </Subject>
+    <Subject>
+      <SubjectSchemeIdentifier>24</SubjectSchemeIdentifier>
+      <SubjectSchemeName>dctr:cdfam</SubjectSchemeName>
+      <SubjectCode>200.20001</SubjectCode>
+    </Subject>
+    <Subject>
+      <SubjectSchemeIdentifier>24</SubjectSchemeIdentifier>
+      <SubjectSchemeName>dctr:cdfam</SubjectSchemeName>
+      <SubjectCode>200.20001.2000115</SubjectCode>
+    </Subject>
   </DescriptiveDetail>
   <CollateralDetail>
     <TextContent>

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -913,4 +913,29 @@ class TestImOnix < Minitest::Test
       assert_equal ["AdobeDrm", "Readium LCP DRM"], @product.protections
     end
   end
+
+  context "with proprietary subject" do
+    setup do
+      message = ONIX::ONIXMessage.new
+      message.parse('test/fixtures/9782752906700.xml')
+
+      @product = message.products.last
+    end
+
+    should "have proprietary subjects" do
+      assert_equal 4, @product.proprietary_categories.size
+
+      assert_equal 'dummy-subject-scheme', @product.proprietary_categories[0].scheme_name
+      assert_equal 'dctr:cdfam', @product.proprietary_categories[1].scheme_name
+      assert_equal 'dctr:cdfam', @product.proprietary_categories[2].scheme_name
+      assert_equal 'dctr:cdfam', @product.proprietary_categories[3].scheme_name
+
+      assert_equal '100', @product.proprietary_categories[0].code
+      assert_equal 'Dummy Subject', @product.proprietary_categories[0].heading_text
+
+      assert_equal '200', @product.proprietary_categories[1].code
+      assert_equal '200.20001', @product.proprietary_categories[2].code
+      assert_equal '200.20001.2000115', @product.proprietary_categories[3].code
+    end
+  end
 end


### PR DESCRIPTION
Je vais avoir besoin d'importer la catégorisation Decitre, donc j'expose une méthode permettant de récupérer les catégorisations qui ne sont pas dans le standard ONIX.