### PR TITLE
Fix supply grouping by territory

### DIFF
--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -630,7 +630,7 @@ module ONIX
       grouped_territories_supplies={}
       grouped_supplies.each do |ksup,supply|
         fsupply=supply.first
-        pr_key="#{fsupply[:available]}_#{fsupply[:including_tax]}_#{fsupply[:currency]}"
+        pr_key="#{fsupply[:available]}_#{fsupply[:including_tax]}_#{fsupply[:currency]}_#{fsupply[:territory].join('_')}"
         supply.each do |s|
           pr_key+="_#{s[:price]}_#{s[:from_date]}_#{s[:until_date]}"
         end


### PR DESCRIPTION
la gem se mélangeait les pinceaux et regroupait des prix qui n'auraient pas dû l'être.

Pour corriger ça, je backport le fix appliqué upstream : https://github.com/immateriel/im_onix/blob/15821fcc47d9095d6316ceec75a06ebd65bb86a3/lib/onix/product.rb#L88