### PR TITLE
NotYetAvailable should not make the product available

### DIFF
--- a/lib/onix/product_supply.rb
+++ b/lib/onix/product_supply.rb
@@ -86,7 +86,7 @@ module ONIX
     end
 
     def available?
-      ["Available","NotYetAvailable","InStock","ToOrder","Pod"].include?(@availability.human)
+      ["Available","InStock","ToOrder","Pod"].include?(@availability.human)
     end
 
     def sold_separately?


### PR DESCRIPTION
NotYetAvailable -> selon moi, ça veut dire "pas disponible", donc la méthode `available?` devrait retourner false.

J'imagine que Immatériel a considéré que NotYetAvailable était disponible car cela voulait dire qu'on pouvait le précommander. Mais cela ne correspond pas à nos besoins, on gère les précommandes différemment. Du coup je propose de faire la modif chez nous sans proposer cette PR à Immatériel.