### PR TITLE
Ajout de l'audience range dans les métadata gérées par im_onix

### DIFF
--- a/lib/onix/code.rb
+++ b/lib/onix/code.rb
@@ -475,4 +475,18 @@ module ONIX
     end
   end
 
+  class AudienceRangeQualifier < CodeFromYaml
+    private
+    def self.code_ident
+      30
+    end
+  end
+
+  class AudienceRangePrecision < CodeFromYaml
+    private
+    def self.code_ident
+      31
+    end
+  end
+
 end

--- a/lib/onix/descriptive_detail.rb
+++ b/lib/onix/descriptive_detail.rb
@@ -303,6 +303,22 @@ module ONIX
     end
   end
 
+  class AudienceRange < Subset
+    attr_accessor :qualifier, :precision, :value
+    def parse(n)
+      n.children.each do |t|
+        case t
+        when tag_match("AudienceRangeQualifier")
+          @qualifier=AudienceRangeQualifier.from_code(t.text)
+        when tag_match("AudienceRangePrecision")
+          @precision=AudienceRangePrecision.from_code(t.text)
+        when tag_match("AudienceRangeValue")
+          @value=t.text
+        end
+      end
+    end
+  end
+
   class ProductFormFeature < Subset
     attr_accessor :type, :value, :descriptions
 
@@ -336,7 +352,8 @@ module ONIX
                   :subjects,
                   :collections,
                   :extents,
-                  :epub_technical_protections
+                  :epub_technical_protections,
+                  :audience_range
 
     def initialize
       @title_details=[]
@@ -352,6 +369,7 @@ module ONIX
       @form_details=[]
       @form_features=[]
       @edition_types=[]
+      @audience_range=[]
     end
 
     # :category: High level
@@ -544,6 +562,8 @@ module ONIX
             @parts << part
           when tag_match("Subject")
             @subjects << Subject.from_xml(t)
+          when tag_match("AudienceRange")
+            @audience_range << AudienceRange.from_xml(t)
         end
       end
 

--- a/test/fixtures/9782752906700.xml
+++ b/test/fixtures/9782752906700.xml
@@ -394,6 +394,16 @@
       <SubjectSchemeName>dctr:cdfam</SubjectSchemeName>
       <SubjectCode>200.20001.2000115</SubjectCode>
     </Subject>
+    <AudienceRange>
+      <AudienceRangeQualifier>17</AudienceRangeQualifier>
+      <AudienceRangePrecision>03</AudienceRangePrecision>
+      <AudienceRangeValue>5</AudienceRangeValue>
+    </AudienceRange>
+    <AudienceRange>
+      <AudienceRangeQualifier>17</AudienceRangeQualifier>
+      <AudienceRangePrecision>04</AudienceRangePrecision>
+      <AudienceRangeValue>8</AudienceRangeValue>
+    </AudienceRange>
   </DescriptiveDetail>
   <CollateralDetail>
     <TextContent>

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -155,13 +155,13 @@ class TestImOnix < Minitest::Test
     should "have an audience range" do
       assert_equal 2, @product.descriptive_detail.audience_range.size
 
-      assert_equal "17", @product.descriptive_detail.audience_range.first.qualifier.code
-      assert_equal "03", @product.descriptive_detail.audience_range.first.precision.code
-      assert_equal "5", @product.descriptive_detail.audience_range.first.value
+      assert_equal "17", @product.descriptive_detail.audience_range.first[:qualifier].code
+      assert_equal "03", @product.descriptive_detail.audience_range.first[:precision].code
+      assert_equal "5", @product.descriptive_detail.audience_range.first[:value]
 
-      assert_equal "17", @product.descriptive_detail.audience_range.last.qualifier.code
-      assert_equal "04", @product.descriptive_detail.audience_range.last.precision.code
-      assert_equal "8", @product.descriptive_detail.audience_range.last.value
+      assert_equal "17", @product.descriptive_detail.audience_range.last[:qualifier].code
+      assert_equal "04", @product.descriptive_detail.audience_range.last[:precision].code
+      assert_equal "8", @product.descriptive_detail.audience_range.last[:value]
     end
   end
 
@@ -601,6 +601,18 @@ class TestImOnix < Minitest::Test
 
     should "have a price to be announced" do
       assert_equal true, @product.price_to_be_announced?
+    end
+
+    should "have an audience range" do
+      assert_equal 2, @product.descriptive_detail.audience_range.size
+
+      assert_equal "17", @product.descriptive_detail.audience_range.first[:qualifier].code
+      assert_equal "03", @product.descriptive_detail.audience_range.first[:precision].code
+      assert_equal "13", @product.descriptive_detail.audience_range.first[:value]
+
+      assert_equal "17", @product.descriptive_detail.audience_range.last[:qualifier].code
+      assert_equal "04", @product.descriptive_detail.audience_range.last[:precision].code
+      assert_equal "99", @product.descriptive_detail.audience_range.last[:value]
     end
   end
 

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -151,6 +151,18 @@ class TestImOnix < Minitest::Test
     should "be priced in Switzerland" do
       assert_equal 1400, @product.supplies_for_country("CH","CHF").first[:prices].first[:amount]
     end
+
+    should "have an audience range" do
+      assert_equal 2, @product.descriptive_detail.audience_range.size
+
+      assert_equal "17", @product.descriptive_detail.audience_range.first.qualifier.code
+      assert_equal "03", @product.descriptive_detail.audience_range.first.precision.code
+      assert_equal "5", @product.descriptive_detail.audience_range.first.value
+
+      assert_equal "17", @product.descriptive_detail.audience_range.last.qualifier.code
+      assert_equal "04", @product.descriptive_detail.audience_range.last.precision.code
+      assert_equal "8", @product.descriptive_detail.audience_range.last.value
+    end
   end
 
   context 'streaming version of "Certaines n’avaient jamais vu la mer"' do


### PR DESCRIPTION
Les _audience ranges_ peuvent être faits de 2 façons différentes dans onix : 

```
<AudienceRange>
    <AudienceRangeQualifier>17</AudienceRangeQualifier>
    <AudienceRangePrecision>03</AudienceRangePrecision>
    <AudienceRangeValue>5</AudienceRangeValue>
</AudienceRange>
<AudienceRange>
    <AudienceRangeQualifier>17</AudienceRangeQualifier>
    <AudienceRangePrecision>04</AudienceRangePrecision>
    <AudienceRangeValue>8</AudienceRangeValue>
</AudienceRange>
```
Ou
```
<AudienceRange>
    <AudienceRangeQualifier>17</AudienceRangeQualifier>
    <AudienceRangePrecision>03</AudienceRangePrecision>
    <AudienceRangeValue>5</AudienceRangeValue>
    <AudienceRangePrecision>04</AudienceRangePrecision>
    <AudienceRangeValue>8</AudienceRangeValue>
</AudienceRange>
```

Ces 2 formats décrivent la même chose (livre pour une audience d'un age de 5 à 8 ans).
La modification dans IM Onix vise à permettre la compréhension des 2.