### PR TITLE
Stop losing notion of main subject

### DIFF
--- a/lib/onix/subject.rb
+++ b/lib/onix/subject.rb
@@ -4,6 +4,7 @@ module ONIX
 
 
     def parse(n)
+      @main=false
       n.children.each do |t|
         case t
           when tag_match("MainSubject")

--- a/lib/onix/subject.rb
+++ b/lib/onix/subject.rb
@@ -1,11 +1,13 @@
 module ONIX
   class Subject < Subset
-    attr_accessor :code, :heading_text, :scheme_identifier, :scheme_name, :scheme_version
+    attr_accessor :code, :heading_text, :scheme_identifier, :scheme_name, :scheme_version, :main
 
 
     def parse(n)
       n.children.each do |t|
         case t
+          when tag_match("MainSubject")
+            @main=true
           when tag_match("SubjectHeadingText")
             @heading_text=t.text.strip
           when tag_match("SubjectCode")

--- a/test/fixtures/9782752906700.xml
+++ b/test/fixtures/9782752906700.xml
@@ -374,6 +374,7 @@
       <SubjectHeadingText>destin de femmes, États-Unis d'Amérique, Asie, Oubli, Amérique du Nord, Guerre, Prix Femina étranger 2012, Exil, Amérique, Japon, mariage forcé</SubjectHeadingText>
     </Subject>
     <Subject>
+      <MainSubject/>
       <SubjectSchemeIdentifier>24</SubjectSchemeIdentifier>
       <SubjectSchemeName>dummy-subject-scheme</SubjectSchemeName>
       <SubjectCode>100</SubjectCode>

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -962,7 +962,7 @@ class TestImOnix < Minitest::Test
       assert_equal '200.20001.2000115', @product.proprietary_categories[3].code
 
       assert_equal true, @product.proprietary_categories[0].main
-      assert_equal true, @product.proprietary_categories[1].main.nil?
+      assert_equal false, @product.proprietary_categories[1].main
     end
   end
 

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -962,6 +962,7 @@ class TestImOnix < Minitest::Test
       assert_equal '200.20001.2000115', @product.proprietary_categories[3].code
 
       assert_equal true, @product.proprietary_categories[0].main
+      assert_equal true, @product.proprietary_categories[1].main.nil?
     end
   end
 

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -960,6 +960,8 @@ class TestImOnix < Minitest::Test
       assert_equal '200', @product.proprietary_categories[1].code
       assert_equal '200.20001', @product.proprietary_categories[2].code
       assert_equal '200.20001.2000115', @product.proprietary_categories[3].code
+
+      assert_equal true, @product.proprietary_categories[0].main
     end
   end
 


### PR DESCRIPTION
Dans le cadre de la story [TSD-69](https://tea-ebook.atlassian.net/browse/TSD-69), il est nécessaire de conserver la notion de "Main Subject". Cette modification la rajoute dans im_onix.