### PR TITLE
Expose precise availability data

### DIFF
--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -522,6 +522,7 @@ module ONIX
     #
     # supplies is a hash symbol array in the form :
     #   [{:available=>bool,
+    #     :availability=>string,
     #     :availability_date=>date,
     #     :including_tax=>bool,
     #     :currency=>string,
@@ -596,7 +597,7 @@ module ONIX
 
       # filter on availability, date, type and territories because suppliers are always the same
       unpriced_items.uniq! do |i|
-        i.select {|k,v| [:available, :availability_date, :unpriced_item_type, :territory].include?(k) }.hash
+        i.select {|k,v| [:available, :availability_date, :availability, :unpriced_item_type, :territory].include?(k) }.hash
       end
 
       grouped_supplies={}
@@ -662,6 +663,7 @@ module ONIX
                      :currency=>fsupply[:currency],
                      :territory=>supply.map{|fs| fs.map{|s| s[:territory]}}.flatten.uniq,
                      :available=>fsupply[:available],
+                     :availability=>fsupply[:availability],
                      :availability_date=>fsupply[:availability_date],
                      :suppliers=>fsupply[:suppliers],
                      :prices=>supply.first.map{|s|

--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -556,6 +556,7 @@ module ONIX
               supply={}
               supply[:suppliers]=sd.suppliers
               supply[:available]=sd.available?
+              supply[:availability]=sd.availability
               supply[:availability_date]=availability_date
 
               supply[:price]=p.amount
@@ -583,6 +584,7 @@ module ONIX
               unpriced_items << {
                 :suppliers => sd.suppliers,
                 :available => sd.available?,
+                :availability => sd.availability,
                 :availability_date => availability_date,
                 :unpriced_item_type => sd.unpriced_item_type.human,
                 :territory => market_territories

--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -557,7 +557,7 @@ module ONIX
               supply={}
               supply[:suppliers]=sd.suppliers
               supply[:available]=sd.available?
-              supply[:availability]=sd.availability
+              supply[:availability]=sd.availability.human
               supply[:availability_date]=availability_date
 
               supply[:price]=p.amount
@@ -585,7 +585,7 @@ module ONIX
               unpriced_items << {
                 :suppliers => sd.suppliers,
                 :available => sd.available?,
-                :availability => sd.availability,
+                :availability => sd.availability.human,
                 :availability_date => availability_date,
                 :unpriced_item_type => sd.unpriced_item_type.human,
                 :territory => market_territories

--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -557,7 +557,7 @@ module ONIX
               supply={}
               supply[:suppliers]=sd.suppliers
               supply[:available]=sd.available?
-              supply[:availability]=sd.availability.human
+              supply[:availability]=sd.availability
               supply[:availability_date]=availability_date
 
               supply[:price]=p.amount
@@ -585,7 +585,7 @@ module ONIX
               unpriced_items << {
                 :suppliers => sd.suppliers,
                 :available => sd.available?,
-                :availability => sd.availability.human,
+                :availability => sd.availability,
                 :availability_date => availability_date,
                 :unpriced_item_type => sd.unpriced_item_type.human,
                 :territory => market_territories

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -140,7 +140,7 @@ class TestImOnix < Minitest::Test
       assert_equal true, @product.supplies_for_country("FR","EUR").first[:available]
     end
 
-    should "has 'Available' availability" do
+    should "have 'Available' availability" do
       assert_equal "Available", @product.supplies_for_country("FR","EUR").first[:availability].human
       assert_equal "20", @product.supplies_for_country("FR","EUR").first[:availability].code
     end

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -140,6 +140,11 @@ class TestImOnix < Minitest::Test
       assert_equal true, @product.supplies_for_country("FR","EUR").first[:available]
     end
 
+    should "has 'Available' availability" do
+      assert_equal "Available", @product.supplies_for_country("FR","EUR").first[:availability].human
+      assert_equal "20", @product.supplies_for_country("FR","EUR").first[:availability].code
+    end
+
     should "be priced in France" do
       assert_equal 1099, @product.supplies_for_country("FR","EUR").first[:prices].first[:amount]
     end


### PR DESCRIPTION
J'ai besoin de l'info précise de dispo plutôt que d'un booléen "available?" qui agrège des données et qui m'empêche d'isoler des cas particuliers.

@cGuille je me souviens que tu avais parlé de gestion de codes et infos en venant des notices, comme quoi fallait faire attention à ne pas trop se reposer sur les docs HTML, mais je ne sais pas trop quoi faire d'autre. On en parle si tu as une meilleure idée ?