### PR TITLE
Update price qualifier code list

### DIFF
--- a/data/codelists/codelist-59.yml
+++ b/data/codelists/codelist-59.yml
@@ -6,7 +6,16 @@
   '03': ReducedPriceApplicableWhenTheItemIsPurchasedAsPartOfASetOrSeriesOrCollection
   '04': VoucherPrice
   '05': ConsumerPrice
-  '06': CorporatePrice
+  '06': CorporateLibraryEducationPrice
   '07': ReservationOrderPrice
   '08': PromotionalOfferPrice
   '09': LinkedPrice
+  '10': LibraryPrice
+  '11': EducationPrice
+  '12': CorporatePrice
+  '13': SubscriptionServicePrice
+  '14': SchoolLibraryPrice
+  '15': AcademicLibraryPrice
+  '16': PublicLibraryPrice
+  '17': IntroductoryPrice
+  '18': ConsortialPrice


### PR DESCRIPTION
I fetched the up-to-date version for the price qualifier code list from the upstream repo.

In the [update-codelists](https://github.com/TEA-ebook/im_onix/compare/master...TEA-ebook:update-codelists) branch, I tried to update **all** code list files, but as there are changes to existing codes I think it is too risky regarding backwards compatibility (tests fail). So I decided to only update this one, because what I need is the new `10` code (`LibraryPrice`).

The new file contains an update that changes the `CorporatePrice` to `CorporateLibraryEducationPrice` for the code `06` and add new codes. I decided to keep `CorporatePrice` for this code to ensure backwards compatibility as well.

Context is the issue [VIV-842](https://tea-ebook.atlassian.net/browse/VIV-842).

