### PR TITLE
Explode all supplies by countries

### DIFF
--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -610,8 +610,18 @@ module ONIX
         i.select {|k,v| [:available, :availability_date, :availability, :unpriced_item_type, :territory].include?(k) }.hash
       end
 
-      grouped_supplies={}
+      # Need to split supplies by territories
+      territoried_supplies = []
       supplies.each do |supply|
+        supply[:territory].each do |territory|
+          newsupply = supply.clone
+          newsupply[:territory] = [territory]
+          territoried_supplies << newsupply
+        end
+      end
+
+      grouped_supplies={}
+      territoried_supplies.each do |supply|
         pr_key="#{supply[:available]}_#{supply[:including_tax]}_#{supply[:currency]}_#{supply[:territory].join('_')}"
         grouped_supplies[pr_key]||=[]
         grouped_supplies[pr_key] << supply

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -439,9 +439,12 @@ class TestImOnix < Minitest::Test
     end
 
     should "have a supply with a price for 3 other countries" do
-      priced_supply = @product.supplies.first
-      assert_equal 1, priced_supply[:prices].size
-      assert_equal 3, priced_supply[:territory].size
+      priced_supplies = @product.supplies.select{|s| s[:prices] }
+      # A supply for each country
+      assert_equal 3, priced_supplies.size
+      priced_supplies.each do |s|
+        assert_equal 1, s[:prices].size
+      end
     end
 
     should "have a supply free of charge for 8 countries" do
@@ -459,12 +462,14 @@ class TestImOnix < Minitest::Test
       @product=@message.products.last
     end
 
-    should "have a supply with a price in Franec" do
-      supply = @product.supplies.first
+    should "have a supply with a price in France" do
+      frsupply = @product.supplies.select {|s| s[:territory].first == "FR"}
 
-      assert_equal 1, supply[:prices].size
-      assert_equal 0, supply[:prices].first[:amount]
-      assert_equal 7, supply[:territory].size
+      assert_equal 8, @product.supplies.size
+      assert_equal 0, @product.supplies.first[:prices].first[:amount]
+
+      assert_equal 1, frsupply.size
+      assert_equal 3000, frsupply.first[:prices].first[:amount]
     end
 
     should "have a supply free of charge for 8 countries" do


### PR DESCRIPTION
Explode all supplies by countries to avoid the case of having:
- supplies with some countries "FR BE CH" for consumer prices
- supplies splitted by country ["FR", "BE", "CH"] for promotional offers

In this case, grouping fail and promo are not recognize as promo of the
consumer prices